### PR TITLE
Fix bottom candidate automatically selected

### DIFF
--- a/autoload/monster/completion/rcodetools/async_rct_complete.vim
+++ b/autoload/monster/completion/rcodetools/async_rct_complete.vim
@@ -39,7 +39,9 @@ function! monster#completion#rcodetools#async_rct_complete#complete(context)
 			return
 		endif
 		if monster#start_complete(0, self.context) == 0
-			call feedkeys("\<C-p>")
+			if &completeopt !~ '\(noinsert\|noselect\)'
+				call feedkeys("\<C-p>")
+			endif
 		endif
 	endfunction
 


### PR DESCRIPTION
すみません、 #4 のfixです。 Shougo/neocomplete.vim#486 でお聞きしたところ、neocomplete.vimを利用するプラグイン側での変更が必要とのことでしたので、こちらで変更しました。

Vim 7.4.827とパッチ775以前の7.4.622で確認したので大丈夫だとは思いますが、念のため @osyo-manga さんにも確認して頂けるとありがたいです。
